### PR TITLE
Don't truncate on xor_strings.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,13 +1,16 @@
 """
 Utility Functions for my crypto exercises.
 """
+
+from itertools import izip_longest
+
 def xor_strings(a, b, hex=False):
     """XOR two strings"""
     if hex:
         a = a.decode('hex')
         b = b.decode('hex')
-
-    return ''.join(chr(ord(x) ^ ord(y)) for x, y in zip(a, b))
+    return ''.join(chr(ord(x) ^ ord(y))
+                   for x, y in izip_longest(a, b, fillvalue="\x00"))
 
 
 def get_random(size=16):


### PR DESCRIPTION
The way this was implemented if you give the function strings of different lengths it will truncate to the shortest. If you wanted to preserve the property:

```
A = "long message"
B = "short msg"
assert A == xor_strings(xor_strings(A, B), B)
```

Then you would have to pad one of the strings out. If you don't want this for confidentiality reasons then I'd raise an exception when provided strings with different lengths so you don't lose data.
