### PR TITLE
Added uppercase alphabet letters, throws ValueError if plaintext with…

### DIFF
--- a/naive/vigenere_cipher.py
+++ b/naive/vigenere_cipher.py
@@ -25,7 +25,7 @@ secure of the group.
 """
 from itertools import cycle
 
-ALPHA = 'abcdefghijklmnopqrstuvwxyz'
+ALPHA = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 
 def encrypt(key, plaintext):


### PR DESCRIPTION
… uppercase letters was given.

Thanks for your article! Just a small fix to account for uppercase letters.
